### PR TITLE
Fixed scroll nav bug

### DIFF
--- a/static/_sass/base/_typography.scss
+++ b/static/_sass/base/_typography.scss
@@ -113,7 +113,7 @@ cite {
   text-align: center;
 
   @include media($tiny-down) {
-    font-size: $base-font-size & 1.424;
+    font-size: $base-font-size * 1.424;
   }
 }
 

--- a/static/js/init.js
+++ b/static/js/init.js
@@ -1,3 +1,6 @@
+$.fn.scrollBottom = function() { 
+  return $(document).height() - this.scrollTop() - this.height(); 
+};
 jQuery(document).ready(function($){
 
   // Quick and Easy Javascript Detection
@@ -79,6 +82,7 @@ jQuery(document).ready(function($){
 
     $(document).scroll(function(){
       scrollPos = $(window).scrollTop();
+      
       if (scrollPos >= navTop) {
         navHeight = $('.page-nav').height();
         $('.page-nav').addClass('fixed');
@@ -102,6 +106,21 @@ jQuery(document).ready(function($){
           $(this).attr('aria-selected', 'false');
         }
       });
+      //fixes bug where the last section was never highlighted by highlighting it when
+      //you scroll to the bottom
+      if ($(window).scrollBottom() <= 0 && $('.page-nav a:last').attr('aria-selected') == 'false')
+      {
+        $('.page-nav a').each(function(){
+          $(this).parent('li').removeClass('current-section');
+          $(this).attr('aria-selected', 'false');
+        });
+        $('.page-nav a:last').each(function(){
+          $('.current-section').removeClass('current-section');
+          $(this).attr('aria-selected', 'true');
+          $(this).parent('li').addClass('current-section');
+          moveProgress();
+        });
+      }
     });
 
     // Scroll down to sections in page nav {


### PR DESCRIPTION
On employers, you could never get the contact us nave tab to highlight. This fixes that by checking if you are scrolled to the bottom of the page and checking if that last tab is highlighted. 
