### PR TITLE
Fix cache time to be an hour

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ jekyll build --config _config.yml,_config-production.yml
 From the project root:
 
 ```bash
-s3cmd  put --recursive --add-header="Cache-Control:max-age=86400" -P _site/* s3://myra-cloudfront/
+s3cmd  put --recursive --add-header="Cache-Control:max-age=3600" -P _site/* s3://myra-cloudfront/
 ```
 
 You can see the results of your work immediately at `http://myra-cloudfront.s3-website-us-east-1.amazonaws.com`.


### PR DESCRIPTION
The docs said the cache time should be an hour, and it's what we've all been planning around. But that's not what we've been using.

86,400 seconds is 60 * 60 * 24 seconds = 1 day.

3600 seconds is 60 * 60 = 1 hour.

Fixes #139.