### PR TITLE
Fix analytics snippet, add DAP reporting

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -53,10 +53,17 @@
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
     ga('create', 'UA-48605964-14', 'auto');
+    // anonymize user IPs (chops off the last IP triplet)
+    ga('set', 'anonymizeIp', true);
+
+    // forces SSL even if the page were somehow loaded over http://
+    ga('set', 'forceSSL', true);
+
     ga('send', 'pageview');
+
     $(document).ready(function(){
       $('form:first').submit(function(){
         ga('send','event','Email Collection','Submit','First Form');
@@ -66,6 +73,10 @@
       });
     })
     </script>
+
+    <!-- Digital Analytics Program roll-up, see https://analytics.usa.gov for data -->
+    <script id="_fed_an_ua_tag" src="https://analytics.usa.gov/dap/dap.min.js"></script>
+
   </footer>
 
   {% include modals.html %}


### PR DESCRIPTION
This updates the Google Analytics snippet to match what we do on `18f.gsa.gov`. IPs are anonymized, and the `forceSSL` flag is triggered so that even if the page were somehow loaded over HTTP, the analytics requests still get fired over HTTPS.

This also adds the DAP reporting snippet, which means that the site will report to the government's Digital Analytics Program. This is an OMB requirement, and an all-around good thing.